### PR TITLE
Restore NewPipeExtractor as fallback

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -140,6 +140,10 @@ kotlin {
                 @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
                 implementation(compose.components.resources)
 
+                /* use `com.github.teamnewpipe` and NOT `com.github.TeamNewPipe`
+                 * its case sensitive and the readme notation DOES NOT WORK */
+                implementation("com.github.teamnewpipe:NewPipeExtractor:v0.22.7")
+
                 implementation(project(":ComposeKit:lib"))
 
                 implementation("com.squareup.okhttp3:okhttp:4.10.0")

--- a/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/playerservice/PlatformPlayerService.android.kt
+++ b/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/playerservice/PlatformPlayerService.android.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
@@ -569,7 +570,7 @@ actual class PlatformPlayerService: MediaSessionService(), PlayerService {
                     throw NotImplementedError()
                 }
 
-                override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> {
+                override fun loadBitmap(uri: Uri, options: BitmapFactory.Options?): ListenableFuture<Bitmap> {
                     return executor.submit<Bitmap> {
                         runBlocking {
                             val song = SongRef(uri.toString())

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/formats/NewPipeVideoFormatsEndpoint.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/formats/NewPipeVideoFormatsEndpoint.kt
@@ -1,0 +1,114 @@
+package com.toasterofbread.spmp.youtubeapi.formats
+
+import com.toasterofbread.spmp.youtubeapi.YoutubeApi
+import com.toasterofbread.spmp.youtubeapi.YoutubeVideoFormat
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.downloader.Downloader
+import org.schabi.newpipe.extractor.downloader.Request
+import org.schabi.newpipe.extractor.downloader.Response
+import org.schabi.newpipe.extractor.exceptions.ParsingException
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory
+import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.StreamInfo
+import org.schabi.newpipe.extractor.stream.VideoStream
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class NewPipeVideoFormatsEndpoint(override val api: YoutubeApi): VideoFormatsEndpoint() {
+
+    private fun VideoStream.toYoutubeVideoFormat(): YoutubeVideoFormat {
+        return YoutubeVideoFormat(itag, format!!.mimeType, bitrate, url = content)
+    }
+
+    private fun AudioStream.toYoutubeVideoFormat(): YoutubeVideoFormat {
+        return YoutubeVideoFormat(itag, format!!.mimeType, bitrate, url = content)
+    }
+
+
+    override suspend fun getVideoFormats(id: String, filter: ((YoutubeVideoFormat) -> Boolean)?): Result<List<YoutubeVideoFormat>> {
+
+        val linkHandler = YoutubeStreamLinkHandlerFactory.getInstance().fromId(id)
+        val youtubeStreamExtractor = NewPipe.getService(ServiceList.YouTube.serviceId).getStreamExtractor(linkHandler)
+
+        val streamInfo = try {
+            StreamInfo.getInfo(youtubeStreamExtractor)
+        } catch (e: ParsingException) {
+            return Result.failure(e)
+        }
+
+        val filteredAudio = streamInfo.audioStreams
+            .map { it.toYoutubeVideoFormat() }
+            .filter { filter?.invoke(it) ?: true }
+
+        val filteredVideo = streamInfo.videoStreams
+            .map { it.toYoutubeVideoFormat() }
+            .filter { filter?.invoke(it) ?: true }
+
+        return Result.success(filteredAudio + filteredVideo)
+    }
+}
+
+
+class CustomDownloader private constructor(builder: OkHttpClient.Builder) : Downloader() {
+    private val client: OkHttpClient = builder.readTimeout(30, TimeUnit.SECONDS).build()
+
+    @Throws(IOException::class, ReCaptchaException::class)
+    override fun execute(request: Request): Response {
+        val httpMethod = request.httpMethod()
+        val url = request.url()
+        val headers = request.headers()
+        val requestBody = request.dataToSend()?.toRequestBody(null, 0)
+
+        val requestBuilder = okhttp3.Request.Builder()
+            .url(url)
+            .method(httpMethod, requestBody)
+            .addHeader("User-Agent", USER_AGENT)
+
+        for ((headerName, headerValueList) in headers) {
+            if (headerValueList.size > 1) {
+                requestBuilder.removeHeader(headerName)
+                for (headerValue in headerValueList) {
+                    requestBuilder.addHeader(headerName, headerValue!!)
+                }
+            } else if (headerValueList.size == 1) {
+                requestBuilder.header(headerName, headerValueList[0])
+            }
+        }
+
+        client.newCall(requestBuilder.build()).execute().use { response ->
+            if (response.code == 429) {
+                throw ReCaptchaException("reCaptcha Challenge requested", url)
+            }
+
+            val responseBodyToReturn = response.body?.string()
+            val latestUrl = response.request.url.toString()
+
+            return Response(
+                response.code, response.message, response.headers.toMultimap(),
+                responseBodyToReturn, latestUrl
+            )
+        }
+    }
+
+
+    companion object {
+        private lateinit var _instance: CustomDownloader
+
+        private fun init(builder: OkHttpClient.Builder = OkHttpClient.Builder()) {
+            _instance = CustomDownloader(builder)
+        }
+
+        fun getInstance(): CustomDownloader {
+            if (!::_instance.isInitialized) { init() }
+            return _instance
+        }
+
+        private const val USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:68.0) Gecko/20100101 Firefox/68.0"
+    }
+
+}

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/formats/VideoFormatsEndpoint.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/formats/VideoFormatsEndpoint.kt
@@ -6,18 +6,21 @@ import com.toasterofbread.spmp.youtubeapi.YoutubeVideoFormat
 
 enum class VideoFormatsEndpointType {
     YOUTUBEI,
-    PIPED;
+    PIPED,
+    NEWPIPE;
   
     fun instantiate(api: YoutubeApi): VideoFormatsEndpoint =
         when(this) {
             YOUTUBEI -> YoutubeiVideoFormatsEndpoint(api)
             PIPED -> PipedVideoFormatsEndpoint(api)
+            NEWPIPE -> NewPipeVideoFormatsEndpoint(api)
         }
 
     fun getReadable(): String =
         when(this) {
             YOUTUBEI -> getString("video_format_endpoint_youtubei")
             PIPED -> getString("video_format_endpoint_piped")
+            NEWPIPE -> getString("video_format_endpoint_newpipe")
         }
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/formats/testVideoFormatMethods.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/formats/testVideoFormatMethods.kt
@@ -16,7 +16,8 @@ suspend fun testVideoFormatMethods(
 
     val methods: Map<String, VideoFormatsEndpoint> = mapOf(
         Pair("Piped", PipedVideoFormatsEndpoint(api)),
-        Pair("Youtubei", YoutubeiVideoFormatsEndpoint(api))
+        Pair("Youtubei", YoutubeiVideoFormatsEndpoint(api)),
+        Pair("NewPipe", NewPipeVideoFormatsEndpoint(api))
     )
 
     println("--- Begin test ---")

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/impl/youtubemusic/YoutubeMusicApi.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/impl/youtubemusic/YoutubeMusicApi.kt
@@ -10,9 +10,9 @@ import com.toasterofbread.composekit.platform.PlatformPreferencesListener
 import com.toasterofbread.db.Database
 import com.toasterofbread.spmp.model.mediaitem.MediaItem
 import com.toasterofbread.spmp.model.settings.Settings
-import com.toasterofbread.spmp.model.settings.category.YoutubeAuthSettings
 import com.toasterofbread.spmp.model.settings.category.StreamingSettings
 import com.toasterofbread.spmp.model.settings.category.SystemSettings
+import com.toasterofbread.spmp.model.settings.category.YoutubeAuthSettings
 import com.toasterofbread.spmp.platform.AppContext
 import com.toasterofbread.spmp.platform.getDataLanguage
 import com.toasterofbread.spmp.platform.getUiLanguage
@@ -22,6 +22,7 @@ import com.toasterofbread.spmp.youtubeapi.YoutubeApi
 import com.toasterofbread.spmp.youtubeapi.YoutubeApi.PostBodyContext
 import com.toasterofbread.spmp.youtubeapi.endpoint.ArtistRadioEndpoint
 import com.toasterofbread.spmp.youtubeapi.executeResult
+import com.toasterofbread.spmp.youtubeapi.formats.CustomDownloader
 import com.toasterofbread.spmp.youtubeapi.formats.VideoFormatsEndpoint
 import com.toasterofbread.spmp.youtubeapi.formats.VideoFormatsEndpointType
 import com.toasterofbread.spmp.youtubeapi.impl.youtubemusic.composable.YTMLoginPage
@@ -53,6 +54,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.apache.commons.text.StringSubstitutor
+import org.schabi.newpipe.extractor.NewPipe
 import java.io.Reader
 import java.time.Duration
 import java.util.logging.Level
@@ -127,6 +129,9 @@ data class YoutubeMusicApi(
                     }
                     launch {
                         updateYtmContext()
+                    }
+                    launch {
+                        NewPipe.init(CustomDownloader.getInstance())
                     }
                 }
             }

--- a/shared/src/commonMain/resources/assets/values/strings.xml
+++ b/shared/src/commonMain/resources/assets/values/strings.xml
@@ -197,6 +197,7 @@
 
     <string name="video_format_endpoint_piped">Piped API</string>
     <string name="video_format_endpoint_youtubei">Youtubei</string>
+    <string name="video_format_endpoint_newpipe">NewPipe</string>
 
     <string name="error_message_generic">A error occurred</string>
     <string name="error_yt_feed_parse_failed">YouTube feed parsing failed</string>


### PR DESCRIPTION
its very unlikely that the APIs go out, but still instead of relying on them to update the API when YouTube makes changes, use the dependency of NewPipeExtractor directly (without any middleman like Piped) to use as a fallback if anything goes wrong with the APIs.

It is slow but it works!