### PR TITLE
Add Gradle tasks for packaging SpMs into SpMp

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,10 +34,10 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: spmp-android-debug.zip
-        path: androidApp/build/outputs/apk/debug/androidApp-debug.apk
+        path: androidApp/build/outputs/apk/debug/*.apk
 
     - name: Upload universal release APK artifact
       uses: actions/upload-artifact@v3
       with:
         name: spmp-android-release.zip
-        path: androidApp/build/outputs/apk/release/androidApp-release.apk
+        path: androidApp/build/outputs/apk/release/*.apk

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -33,11 +33,11 @@ jobs:
     - name: Upload universal debug APK artifact
       uses: actions/upload-artifact@v3
       with:
-        name: androidApp-debug.apk
+        name: spmp-android-debug.zip
         path: androidApp/build/outputs/apk/debug/androidApp-debug.apk
 
     - name: Upload universal release APK artifact
       uses: actions/upload-artifact@v3
       with:
-        name: androidApp-release.apk
+        name: spmp-android-release.zip
         path: androidApp/build/outputs/apk/release/androidApp-release.apk

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -35,10 +35,10 @@ jobs:
       run: chmod +x /usr/local/bin/appimagetool
 
     - name: Build AppImage
-      run: ./gradlew desktopApp:actuallyPackageAppImage
+      run: ./gradlew desktopApp:packageReleaseAppImageWithServer
 
     - name: Upload AppImage artifact
       uses: actions/upload-artifact@v3
       with:
         name: spmp-linux-release.zip
-        path: desktopApp/build/*.appimage
+        path: desktopApp/build/compose/binaries/main-release/appimage/*.appimage

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -40,5 +40,5 @@ jobs:
     - name: Upload AppImage artifact
       uses: actions/upload-artifact@v3
       with:
-        name: desktopApp-release.appimage
+        name: spmp-linux-release.zip
         path: desktopApp/build/*.appimage

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Upload exe artifact
       uses: actions/upload-artifact@v3
       with:
-        name: desktopApp-release.exe
-        path: desktopApp/build/compose/binaries/main-release/exe/*.exe
+        name: spmp-windows-release.zip
+        path: desktopApp/build/compose/binaries/main-release/exe/*

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,4 +29,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: spmp-windows-release.zip
-        path: desktopApp/build/compose/binaries/main-release/exe/*
+        path: desktopApp/build/compose/binaries/main-release/exe/*.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Build exe
-      run: .\gradlew.bat desktopApp:packageReleaseExe
+      run: .\gradlew.bat desktopApp:packageReleaseExeWithServer
 
     - name: Upload exe artifact
       uses: actions/upload-artifact@v3

--- a/desktopApp/appimage/AppRun
+++ b/desktopApp/appimage/AppRun
@@ -13,4 +13,4 @@ EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cu
 cd $HERE
 
 echo "Running SpMp..."
-exec "${EXEC}" "--bin-dir=${HERE}/bin" "$@"
+exec "${EXEC}" "$@"

--- a/desktopApp/appimage/AppRun
+++ b/desktopApp/appimage/AppRun
@@ -13,4 +13,4 @@ EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cu
 cd $HERE
 
 echo "Running SpMp..."
-exec "${EXEC}" "$@"
+exec "${EXEC}" "--bin-dir=${HERE}/bin" "$@"

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -115,7 +115,7 @@ abstract class PackageTask: DefaultTask() {
     companion object {
         const val FLAG_PACKAGE_SERVER: String = "packageServer"
 
-        fun getResourcesDir(project: Project, os: OS) =
+        fun getResourcesDir(project: Project, os: OS): File =
             when (os) {
                 OS.LINUX -> project.file("build/package/linux")
                 OS.WINDOWS -> project.file("build/package/windows")
@@ -248,7 +248,7 @@ abstract class ActuallyPackageAppImageTask: PackageTask() {
         val icon_dst: File = icon_dst_file.get().asFile
         icon_src.copyTo(icon_dst, overwrite = true)
 
-        val server_dst_dir: File = getResourcesDir(project, OS.LINUX)
+        val server_dst_dir: File = appimage_dst.resolve("bin")
         if (project.hasProperty(FLAG_PACKAGE_SERVER)) {
             downloadPlatformServer(OS.LINUX, server_props_file.get().asFile, server_dst_dir)
         }

--- a/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/desktopApp/src/jvmMain/kotlin/main.kt
@@ -19,29 +19,10 @@ import kotlinx.coroutines.*
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 import java.awt.Toolkit
-import java.io.File
 import java.lang.reflect.Field
 
 @OptIn(ExperimentalComposeUiApi::class)
-fun main(args: Array<String>) {
-    var server_executable_path: String? = null
-    val server_executable_filename: String? = getServerExecutableFilename()
-
-    if (server_executable_filename != null) {
-        for (arg in args) {
-            if (!arg.startsWith("--bin-dir=")) {
-                continue
-            }
-
-            val server_executable = File(arg.drop(10).trim().trim('\'', '"')).resolve(server_executable_filename)
-            if (server_executable.isFile) {
-                server_executable_path = server_executable.absolutePath
-            }
-
-            break
-        }
-    }
-
+fun main() {
     val coroutine_scope: CoroutineScope = CoroutineScope(Job())
 
     val context: AppContext = AppContext(SpMp.app_name, coroutine_scope)
@@ -142,8 +123,7 @@ fun main(args: Array<String>) {
                     if (event.button?.index == 5) {
                         onWindowBackPressed()
                     }
-                },
-                server_executable_path = server_executable_path
+                }
             )
         }
     }
@@ -153,10 +133,3 @@ fun main(args: Array<String>) {
     SpMp.onStop()
     SpMp.release()
 }
-
-fun getServerExecutableFilename(): String? =
-    when (hostOs) {
-        OS.Linux -> "spms.kexe"
-        OS.Windows -> "spms.exe"
-        else -> null
-    }

--- a/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/desktopApp/src/jvmMain/kotlin/main.kt
@@ -13,16 +13,38 @@ import com.toasterofbread.composekit.platform.composable.onWindowBackPressed
 import com.toasterofbread.spmp.model.settings.category.DesktopSettings
 import com.toasterofbread.spmp.model.settings.category.SystemSettings
 import com.toasterofbread.spmp.platform.AppContext
+import com.toasterofbread.spmp.platform.playerservice.getServerExecutableFilename
 import com.toasterofbread.spmp.ui.layout.apppage.mainpage.getTextFieldFocusState
 import com.toasterofbread.spmp.ui.layout.apppage.mainpage.isTextFieldFocused
 import kotlinx.coroutines.*
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 import java.awt.Toolkit
+import java.io.File
 import java.lang.reflect.Field
 
 @OptIn(ExperimentalComposeUiApi::class)
-fun main() {
+fun main(args: Array<String>) {
+    var server_executable_path: String? = null
+    val server_executable_filename: String? = getServerExecutableFilename()
+
+    if (server_executable_filename != null) {
+        for (arg in args) {
+            if (!arg.startsWith("--bin-dir=")) {
+                continue
+            }
+
+            val server_executable: File =
+                File(arg.drop(10).trim().trim('\'', '"'))
+                    .resolve(server_executable_filename)
+            if (server_executable.isFile) {
+                server_executable_path = server_executable.absolutePath
+            }
+
+            break
+        }
+    }
+
     val coroutine_scope: CoroutineScope = CoroutineScope(Job())
 
     val context: AppContext = AppContext(SpMp.app_name, coroutine_scope)
@@ -123,7 +145,8 @@ fun main() {
                     if (event.button?.index == 5) {
                         onWindowBackPressed()
                     }
-                }
+                },
+                server_executable_path = server_executable_path
             )
         }
     }

--- a/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/desktopApp/src/jvmMain/kotlin/main.kt
@@ -19,10 +19,29 @@ import kotlinx.coroutines.*
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 import java.awt.Toolkit
+import java.io.File
 import java.lang.reflect.Field
 
 @OptIn(ExperimentalComposeUiApi::class)
-fun main() {
+fun main(args: Array<String>) {
+    var server_executable_path: String? = null
+    val server_executable_filename: String? = getServerExecutableFilename()
+
+    if (server_executable_filename != null) {
+        for (arg in args) {
+            if (!arg.startsWith("--bin-dir=")) {
+                continue
+            }
+
+            val server_executable = File(arg.drop(10).trim().trim('\'', '"')).resolve(server_executable_filename)
+            if (server_executable.isFile) {
+                server_executable_path = server_executable.absolutePath
+            }
+
+            break
+        }
+    }
+
     val coroutine_scope: CoroutineScope = CoroutineScope(Job())
 
     val context: AppContext = AppContext(SpMp.app_name, coroutine_scope)
@@ -123,7 +142,8 @@ fun main() {
                     if (event.button?.index == 5) {
                         onWindowBackPressed()
                     }
-                }
+                },
+                server_executable_path = server_executable_path
             )
         }
     }
@@ -133,3 +153,10 @@ fun main() {
     SpMp.onStop()
     SpMp.release()
 }
+
+fun getServerExecutableFilename(): String? =
+    when (hostOs) {
+        OS.Linux -> "spms.kexe"
+        OS.Windows -> "spms.exe"
+        else -> null
+    }

--- a/server.properties
+++ b/server.properties
@@ -1,2 +1,2 @@
-SPMS_TARGET_URL_LINUX="https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-linux.kexe"
-SPMS_TARGET_URL_WINDOWS="https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-windows.exe"
+SPMS_TARGET_URL_LINUX=https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-linux.kexe
+SPMS_TARGET_URL_WINDOWS=https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-windows.exe

--- a/server.properties
+++ b/server.properties
@@ -1,0 +1,2 @@
+SPMS_TARGET_URL_LINUX="https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-linux.kexe"
+SPMS_TARGET_URL_WINDOWS="https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-windows.exe"

--- a/server.properties
+++ b/server.properties
@@ -1,2 +1,2 @@
 SPMS_TARGET_URL_LINUX=https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-linux.kexe
-SPMS_TARGET_URL_WINDOWS=https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-windows.exe
+SPMS_TARGET_URL_WINDOWS=https://github.com/toasterofbread/spmp-server/releases/download/release-test/spmp-server-windows.zip

--- a/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/playerservice/SpMs.android.kt
+++ b/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/playerservice/SpMs.android.kt
@@ -3,3 +3,6 @@ package com.toasterofbread.spmp.platform.playerservice
 actual fun getSpMsMachineId(): String {
     TODO("Not yet implemented")
 }
+
+actual fun getServerExecutableFilename(): String? =
+    null

--- a/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.android.kt
@@ -4,4 +4,4 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun SplashExtraLoadingContent(modifier: Modifier, server_executable_path: String?) {}
+actual fun SplashExtraLoadingContent(modifier: Modifier) {}

--- a/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.android.kt
@@ -4,5 +4,4 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun SplashExtraLoadingContent(modifier: Modifier) {
-}
+actual fun SplashExtraLoadingContent(modifier: Modifier, server_executable_path: String?) {}

--- a/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.android.kt
@@ -4,4 +4,4 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun SplashExtraLoadingContent(modifier: Modifier) {}
+actual fun SplashExtraLoadingContent(modifier: Modifier, server_executable_path: String?) {}

--- a/shared/src/commonMain/kotlin/SpMp.kt
+++ b/shared/src/commonMain/kotlin/SpMp.kt
@@ -81,7 +81,11 @@ object SpMp {
     }
 
     @Composable
-    fun App(modifier: Modifier = Modifier, open_uri: String? = null) {
+    fun App(
+        modifier: Modifier = Modifier,
+        open_uri: String? = null,
+        server_executable_path: String? = null
+    ) {
         context.theme.Update()
 
         context.theme.ApplicationTheme(context, getFontFamily(context) ?: FontFamily.Default) {
@@ -123,7 +127,8 @@ object SpMp {
                                 .fillMaxSize()
                                 .thenIf(splash_mode != null) {
                                     pointerInput(Unit) {}
-                                }
+                                },
+                            server_executable_path = server_executable_path
                         )
 
                         if (splash_mode == null) {

--- a/shared/src/commonMain/kotlin/SpMp.kt
+++ b/shared/src/commonMain/kotlin/SpMp.kt
@@ -83,8 +83,7 @@ object SpMp {
     @Composable
     fun App(
         modifier: Modifier = Modifier,
-        open_uri: String? = null,
-        server_executable_path: String? = null
+        open_uri: String? = null
     ) {
         context.theme.Update()
 
@@ -127,8 +126,7 @@ object SpMp {
                                 .fillMaxSize()
                                 .thenIf(splash_mode != null) {
                                     pointerInput(Unit) {}
-                                },
-                            server_executable_path = server_executable_path
+                                }
                         )
 
                         if (splash_mode == null) {

--- a/shared/src/commonMain/kotlin/SpMp.kt
+++ b/shared/src/commonMain/kotlin/SpMp.kt
@@ -83,7 +83,8 @@ object SpMp {
     @Composable
     fun App(
         modifier: Modifier = Modifier,
-        open_uri: String? = null
+        open_uri: String? = null,
+        server_executable_path: String? = null
     ) {
         context.theme.Update()
 
@@ -126,7 +127,8 @@ object SpMp {
                                 .fillMaxSize()
                                 .thenIf(splash_mode != null) {
                                     pointerInput(Unit) {}
-                                }
+                                },
+                            server_executable_path = server_executable_path
                         )
 
                         if (splash_mode == null) {

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/model/settings/category/DesktopSettings.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/model/settings/category/DesktopSettings.kt
@@ -36,8 +36,8 @@ data object DesktopSettings: SettingsCategory("desktop") {
                 STARTUP_COMMAND -> ""
                 SERVER_IP_ADDRESS -> "127.0.0.1"
                 SERVER_PORT -> ProjectBuildConfig.SERVER_PORT ?: 3973
-                SERVER_LOCAL_COMMAND -> "spms"
-                SERVER_LOCAL_START_AUTOMATICALLY -> false
+                SERVER_LOCAL_COMMAND -> ""
+                SERVER_LOCAL_START_AUTOMATICALLY -> true
                 SERVER_KILL_CHILD_ON_EXIT -> true
             } as T
     }

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/platform/playerservice/SpMs.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/platform/playerservice/SpMs.kt
@@ -95,3 +95,5 @@ enum class SpMsClientType {
 }
 
 expect fun getSpMsMachineId(): String
+
+expect fun getServerExecutableFilename(): String?

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.kt
@@ -4,4 +4,4 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-expect fun SplashExtraLoadingContent(modifier: Modifier = Modifier, server_executable_path: String? = null)
+expect fun SplashExtraLoadingContent(modifier: Modifier = Modifier)

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/platform/splash/ExtraLoadingContent.kt
@@ -4,4 +4,4 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-expect fun SplashExtraLoadingContent(modifier: Modifier = Modifier)
+expect fun SplashExtraLoadingContent(modifier: Modifier = Modifier, server_executable_path: String? = null)

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/ui/layout/apppage/mainpage/LoadingSplashView.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/ui/layout/apppage/mainpage/LoadingSplashView.kt
@@ -64,7 +64,8 @@ enum class SplashMode {
 fun LoadingSplashView(
     splash_mode: SplashMode?,
     loading_message: String?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    server_executable_path: String? = null
 ) {
     val player: PlayerState = LocalPlayerState.current
 
@@ -142,7 +143,8 @@ fun LoadingSplashView(
                             .thenIf(!show_message) {
                                 blockGestures()
                             }
-                            .graphicsLayer { alpha = extra_content_alpha }
+                            .graphicsLayer { alpha = extra_content_alpha },
+                        server_executable_path = server_executable_path
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/ui/layout/apppage/mainpage/LoadingSplashView.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/ui/layout/apppage/mainpage/LoadingSplashView.kt
@@ -64,8 +64,7 @@ enum class SplashMode {
 fun LoadingSplashView(
     splash_mode: SplashMode?,
     loading_message: String?,
-    modifier: Modifier = Modifier,
-    server_executable_path: String? = null
+    modifier: Modifier = Modifier
 ) {
     val player: PlayerState = LocalPlayerState.current
 
@@ -143,8 +142,7 @@ fun LoadingSplashView(
                             .thenIf(!show_message) {
                                 blockGestures()
                             }
-                            .graphicsLayer { alpha = extra_content_alpha },
-                        server_executable_path = server_executable_path
+                            .graphicsLayer { alpha = extra_content_alpha }
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/ui/layout/apppage/mainpage/LoadingSplashView.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/ui/layout/apppage/mainpage/LoadingSplashView.kt
@@ -61,7 +61,12 @@ enum class SplashMode {
 }
 
 @Composable
-fun LoadingSplashView(splash_mode: SplashMode?, loading_message: String?, modifier: Modifier = Modifier) {
+fun LoadingSplashView(
+    splash_mode: SplashMode?,
+    loading_message: String?,
+    modifier: Modifier = Modifier,
+    server_executable_path: String? = null
+) {
     val player: PlayerState = LocalPlayerState.current
 
     var show_message: Boolean by remember { mutableStateOf(false) }
@@ -138,7 +143,8 @@ fun LoadingSplashView(splash_mode: SplashMode?, loading_message: String?, modifi
                             .thenIf(!show_message) {
                                 blockGestures()
                             }
-                            .graphicsLayer { alpha = extra_content_alpha }
+                            .graphicsLayer { alpha = extra_content_alpha },
+                        server_executable_path = server_executable_path
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/impl/youtubemusic/YTMUserAuthStateEndpoint.kt
+++ b/shared/src/commonMain/kotlin/com/toasterofbread/spmp/youtubeapi/impl/youtubemusic/YTMUserAuthStateEndpoint.kt
@@ -40,8 +40,6 @@ class YTMUserAuthStateEndpoint(
                 .postWithBody()
                 .build()
 
-            println("HEADERS ${request.headers}")
-
             val result: Result<Response> = api.performRequest(request)
             val data: YTAccountMenuResponse = result.parseJsonResponse {
                 return@withContext Result.failure(it)

--- a/shared/src/commonMain/resources/assets/values-ja-JP/strings.xml
+++ b/shared/src/commonMain/resources/assets/values-ja-JP/strings.xml
@@ -230,6 +230,7 @@
     <string name="desktop_splash_button_start_server">ローカルサーバーを実行</string>
     <string name="desktop_splash_button_stop_process">プロセスを停止</string>
     <string name="desktop_splash_process_running_with_command_$x">このコマンドでプロセスが実行しています:&#xA;$x</string>
+    <string name="desktop_splash_local_server_command_not_set">ローカルサーバーの実行コマンドが設定されていません</string>
 
     <string name="throw_error">スロー</string>
     <string name="report_error">報告する</string>

--- a/shared/src/commonMain/resources/assets/values/strings.xml
+++ b/shared/src/commonMain/resources/assets/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="desktop_splash_button_start_server">Start local server</string>
     <string name="desktop_splash_button_stop_process">Stop process</string>
     <string name="desktop_splash_process_running_with_command_$x">Process running with this command:&#xA;$x</string>
+    <string name="desktop_splash_local_server_command_not_set">Local server command not set</string>
 
     <string name="throw_error">Throw</string>
     <string name="report_error">Report</string>

--- a/shared/src/desktopMain/kotlin/com/toasterofbread/spmp/platform/playerservice/SpMs.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/toasterofbread/spmp/platform/playerservice/SpMs.desktop.kt
@@ -30,3 +30,10 @@ actual fun getSpMsMachineId(): String {
 
     return new_id
 }
+
+actual fun getServerExecutableFilename(): String? =
+    when (hostOs) {
+        OS.Linux -> "spms.kexe"
+        OS.Windows -> "spms.exe"
+        else -> null
+    }


### PR DESCRIPTION
Adds two Gradle tasks:
- packageReleaseAppImageWithServer
- packageReleaseExeWithServer

And updates the Linux and Windows workflows to use these tasks.
This also updates the naming for workflow artifact uploads to be more consistent (including Android).